### PR TITLE
Fix double IVAR_SIGN encoding strings

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -312,7 +312,6 @@ func (e *Encoder) marshal(v interface{}) error {
 		e.w.WriteByte(FIXNUM_SIGN)
 		return e.encInt(int(val.Int()))
 	case reflect.String:
-		e.w.WriteByte(IVAR_SIGN)
 		return e.encString(val.String())
 	}
 	return nil


### PR DESCRIPTION
There are two IVAR_SIGN when strings are encoded

https://github.com/dozen/ruby-marshal/blob/master/marshal.go#L385

https://github.com/dozen/ruby-marshal/blob/master/marshal.go#L315