### PR TITLE
Add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/dozen/ruby-marshal
+
+go 1.17


### PR DESCRIPTION
This PR adds the `go.mod` file with Go 1.17 set as the [minimum required version](https://go.dev/doc/modules/gomod-ref); feel free to change it to any other Go version that suits your needs.