### PR TITLE
fix parseString bug not expecting io.reader.Read partial returns

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -157,7 +157,7 @@ func (d *Decoder) parseObjectLink() interface{} {
 func (d *Decoder) parseString() string {
 	len := d.parseInt()
 	str := make([]byte, len)
-	d.r.Read(str)
+	io.ReadFull(d.r, str)
 	return string(str)
 }
 


### PR DESCRIPTION
io.reader.Read can and will return less data than asked which produces parsing errors like "raw_string len=93 "normal string suddenly containing zeros^@...^@"" and decoding being broken afterwards...

use ioReadFull instead, which is guaranteed to return number of bytes asked

without this patch i was unable to decode most files here (all >100MB in size)