### PR TITLE
T/improve unmarshal, better error msgs and partial obj ref link support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dozen/ruby-marshal
 
-go 1.17
+go 1.25.4

--- a/marshal.go
+++ b/marshal.go
@@ -60,13 +60,13 @@ func (d *Decoder) unmarshal() interface{} {
 	case SYMBOL_LINK_SIGN: // ; - symbol symlink
 		return d.parseSymLink()
 	case OBJECT_LINK_SIGN: // @ - object link
-		panic("not supported.")
+		panic("Object link not supported.")
 	case IVAR_SIGN: // I - IVAR (encoded string or regexp)
 		return d.parseIvar()
 	case ARRAY_SIGN: // [ - array
 		return d.parseArray()
 	case OBJECT_SIGN: // o - object
-		panic("not supported.")
+		panic("Object not supported.")
 	case HASH_SIGN: // { - hash
 		return d.parseHash()
 	case BIGNUM_SIGN: // l - bignum

--- a/marshal.go
+++ b/marshal.go
@@ -60,7 +60,7 @@ func (d *Decoder) unmarshal() interface{} {
 	case SYMBOL_LINK_SIGN: // ; - symbol symlink
 		return d.parseSymLink()
 	case OBJECT_LINK_SIGN: // @ - object link
-		panic("Object link not supported.")
+		return d.parseObjectLink()
 	case IVAR_SIGN: // I - IVAR (encoded string or regexp)
 		return d.parseIvar()
 	case ARRAY_SIGN: // [ - array
@@ -186,6 +186,10 @@ func (d *Decoder) parseArray() interface{} {
 	size := d.parseInt()
 	arr := make([]interface{}, size)
 
+	// hack, but makes referencing iVars work because offsets are correct
+	ivar := iVar{"(array)"}
+	d.objects = append(d.objects, ivar)
+
 	for i := 0; i < int(size); i++ {
 		arr[i] = d.unmarshal()
 	}
@@ -196,10 +200,19 @@ func (d *Decoder) parseHash() interface{} {
 	size := d.parseInt()
 	hash := make(map[string]interface{}, size)
 
+	// hack, but makes referencing iVars work because offsets are correct
+	ivar := iVar{"(hash)"}
+	d.objects = append(d.objects, ivar)
+
 	for i := 0; i < int(size); i++ {
 		key := d.unmarshal()
+
+		keyString := key.(string)
+		ivar := iVar{keyString}
+		d.objects = append(d.objects, ivar)
+
 		value := d.unmarshal()
-		hash[key.(string)] = value
+		hash[keyString] = value
 	}
 
 	return hash


### PR DESCRIPTION
1. patch improves error messages on unmarshal
2. patch adds partial support for obj ref link support

obj ref-link support is actually a hack that creates dummy refs for hashes and arrays, but it works at least to make all iVar refs resolveable correctly (tested with GB's of gitlab `language-stats.cache` files)